### PR TITLE
Updated gemspec to 0.3.1

### DIFF
--- a/streama.gemspec
+++ b/streama.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{streama}
-  s.version = "0.3.0"
+  s.version = "0.3.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Christos Pappas"]


### PR DESCRIPTION
Looks like the VERSION was bumped but gemspec wasn't regenerated. I simply generated the gemspec using "rake gemspec".
