### PR TITLE
Allow optional cache

### DIFF
--- a/lib/streama/activity.rb
+++ b/lib/streama/activity.rb
@@ -104,7 +104,7 @@ module Streama
       
           hash = {'id' => object.id, 'type' => object.class.name}
                 
-          if fields = definition.send(type)[class_sym][:cache]
+          if fields = definition.send(type)[class_sym].try(:[],:cache)
             fields.each do |field|
               raise Streama::InvalidField.new(field) unless object.respond_to?(field)
               hash[field.to_s] = object.send(field)

--- a/spec/lib/actor_spec.rb
+++ b/spec/lib/actor_spec.rb
@@ -1,54 +1,67 @@
 require 'spec_helper'
 
 describe "Actor" do
-  
+
   let(:enquiry) { Enquiry.create(:comment => "I'm interested") }
   let(:listing) { Listing.create(:title => "A test listing") }
   let(:user) { User.create(:full_name => "Christos") }
-  
+
+  new_activities  = [:new_enquiry, :new_enquiry_without_cache]
+
   before :all do
     Activity.activity :new_comment do
       actor :user, :cache => [:full_name]
       object :listing, :cache => [:title]
       target :listing, :cache => [:title]
     end
+
+    Activity.activity :new_enquiry_without_cache do
+      actor :user
+      object :enquiry
+      object :listing
+      target :listing
+    end
+
   end
-  
-  describe "#publish_activity" do
-    
-    before :each do
-      5.times { |n| User.create(:full_name => "Receiver #{n}") }
+
+  new_activities.each do |new_activity|
+    describe "#publish_activity" do
+      before :each do
+        5.times { |n| User.create(:full_name => "Receiver #{n}") }
+      end
+
+      it "pushes activity to receivers" do
+        activity = user.publish_activity(new_activity, :object => enquiry, :target => listing)
+        activity.receivers.size == 6
+      end
+
+      it "pushes to a defined stream" do
+        activity = user.publish_activity(new_activity, :object => enquiry, :target => listing, :receivers => :friends)
+        activity.receivers.size == 6
+      end
     end
-    
-    it "pushes activity to receivers" do
-      activity = user.publish_activity(:new_enquiry, :object => enquiry, :target => listing)
-      activity.receivers.size == 6
-    end
-    
-    it "pushes to a defined stream" do
-      activity = user.publish_activity(:new_enquiry, :object => enquiry, :target => listing, :receivers => :friends)
-      activity.receivers.size == 6
-    end
-    
+
   end
-  
-  describe "#activity_stream" do
-    
-    before :each do
-      5.times { |n| User.create(:full_name => "Receiver #{n}") }
-      user.publish_activity(:new_enquiry, :object => enquiry, :target => listing)
-      user.publish_activity(:new_comment, :object => listing)
+
+  new_activities.each do |new_activity|
+    describe "#activity_stream" do
+
+      before :each do
+        5.times { |n| User.create(:full_name => "Receiver #{n}") }
+        user.publish_activity(new_activity, :object => enquiry, :target => listing)
+        user.publish_activity(:new_comment, :object => listing)
+      end
+
+      it "retrieves the stream for an actor" do
+        user.activity_stream.size.should eq 2
+      end
+
+      it "retrieves the stream and filters to a particular activity type" do
+        user.activity_stream(:type => :new_comment).size.should eq 1
+      end
+
     end
-    
-    it "retrieves the stream for an actor" do
-      user.activity_stream.size.should eq 2
-    end
-    
-    it "retrieves the stream and filters to a particular activity type" do
-      user.activity_stream(:type => :new_comment).size.should eq 1
-    end
-        
   end
-  
-  
+
+
 end


### PR DESCRIPTION
There are exceptions when :cache is not defined.
Although we can define :cache=>[] as a workaround, it might be better to allow an optional 'cache'.

There should be a better way to write the spec. Any thoughts?
