### PR TITLE
Removing InstanceMethods module

### DIFF
--- a/lib/streama/activity.rb
+++ b/lib/streama/activity.rb
@@ -63,61 +63,56 @@ module Streama
       
     end
 
+    # Publishes the activity to the receivers
+    #
+    # @param [ Hash ] options The options to publish with.
+    #
+    def publish(options = {})
+      actor = load_instance(:actor)
+      self.receivers = (options[:receivers] || actor.followers).map { |r| { :id => r.id, :type => r.class.to_s } }
+      self.save
+      self
+    end
 
-    module InstanceMethods
-      
-      # Publishes the activity to the receivers
-      #
-      # @param [ Hash ] options The options to publish with.
-      #
-      def publish(options = {})
-        actor = load_instance(:actor)        
-        self.receivers = (options[:receivers] || actor.followers).map { |r| { :id => r.id, :type => r.class.to_s } }
-        self.save
-        self
-      end
-      
-      # Returns an instance of an actor, object or target
-      #
-      # @param [ Symbol ] type The data type (actor, object, target) to return an instance for.
-      #
-      # @return [Mongoid::Document] document A mongoid document instance
-      def load_instance(type)
-        (data = self.send(type)).is_a?(Hash) ? data['type'].to_s.camelcase.constantize.find(data['id']) : data
-      end
-    
-      def refresh_data
-        assign_data
-        save(:validate => false)
-      end
-    
-      protected
-        
-      def assign_data
-      
-        [:actor, :object, :target].each do |type|
-          next unless object = load_instance(type)
+    # Returns an instance of an actor, object or target
+    #
+    # @param [ Symbol ] type The data type (actor, object, target) to return an instance for.
+    #
+    # @return [Mongoid::Document] document A mongoid document instance
+    def load_instance(type)
+      (data = self.send(type)).is_a?(Hash) ? data['type'].to_s.camelcase.constantize.find(data['id']) : data
+    end
 
-          class_sym = object.class.name.underscore.to_sym
+    def refresh_data
+      assign_data
+      save(:validate => false)
+    end
 
-          raise Streama::InvalidData.new(class_sym) unless definition.send(type).has_key?(class_sym)
-      
-          hash = {'id' => object.id, 'type' => object.class.name}
-                
-          if fields = definition.send(type)[class_sym][:cache]
-            fields.each do |field|
-              raise Streama::InvalidField.new(field) unless object.respond_to?(field)
-              hash[field.to_s] = object.send(field)
-            end
+    protected
+
+    def assign_data
+
+      [:actor, :object, :target].each do |type|
+        next unless object = load_instance(type)
+
+        class_sym = object.class.name.underscore.to_sym
+
+        raise Streama::InvalidData.new(class_sym) unless definition.send(type).has_key?(class_sym)
+
+        hash = {'id' => object.id, 'type' => object.class.name}
+
+        if fields = definition.send(type)[class_sym][:cache]
+          fields.each do |field|
+            raise Streama::InvalidField.new(field) unless object.respond_to?(field)
+            hash[field.to_s] = object.send(field)
           end
-          write_attribute(type, hash)      
         end
+        write_attribute(type, hash)
       end
-    
-      def definition
-        @definition ||= Streama::Definition.find(verb)
-      end
-      
+    end
+
+    def definition
+      @definition ||= Streama::Definition.find(verb)
     end
     
   end

--- a/lib/streama/actor.rb
+++ b/lib/streama/actor.rb
@@ -15,29 +15,26 @@ module Streama
       
     end
 
-    module InstanceMethods
-      
-      # Publishes the activity to the receivers
-      #
-      # @param [ Hash ] options The options to publish with.
-      #
-      # @example publish an activity with a object and target
-      #   current_user.publish_activity(:enquiry, :object => @enquiry, :target => @listing)
-      #
-      def publish_activity(name, options={})
-        options[:receivers] = self.send(options[:receivers]) if options[:receivers].is_a?(Symbol)
-        activity = activity_class.publish(name, {:actor => self}.merge(options))
-      end
-    
-      def activity_stream(options = {})
-        activity_class.stream_for(self, options)
-      end
-      
-      def activity_class
-        @activity_klass ||= activity_klass ? activity_klass.classify.constantize : ::Activity
-      end
+    # Publishes the activity to the receivers
+    #
+    # @param [ Hash ] options The options to publish with.
+    #
+    # @example publish an activity with a object and target
+    #   current_user.publish_activity(:enquiry, :object => @enquiry, :target => @listing)
+    #
+    def publish_activity(name, options={})
+      options[:receivers] = self.send(options[:receivers]) if options[:receivers].is_a?(Symbol)
+      activity = activity_class.publish(name, {:actor => self}.merge(options))
     end
-    
+
+    def activity_stream(options = {})
+      activity_class.stream_for(self, options)
+    end
+
+    def activity_class
+      @activity_klass ||= activity_klass ? activity_klass.classify.constantize : ::Activity
+    end
+
   end
   
 end


### PR DESCRIPTION
Causes all kinds of deprecations warnings in Rails 3.2. 

Thanks!
